### PR TITLE
removed hirak/prestissimo from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apk update && apk upgrade\
 RUN apk add mysql-client --update --no-cac
 RUN apk add wget curl git php php-curl php-openssl php-json php-phar php-dom php-intl --update && rm /var/cache/apk/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
-RUN composer global require hirak/prestissimo
 RUN apk add --update nodejs nodejs-npm
 
 ENV GD_DEPS freetype libpng libjpeg-turbo freetype-dev libpng-dev libjpeg-turbo-dev


### PR DESCRIPTION
Was using this installer and found out that Composer 2 works if hirak/prestissimo was deleted from the Dockerfile.

So decided to make a PR to fix this "issue"